### PR TITLE
docs: add Node version pinning note to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 # 1. Use an official Node.js runtime as a parent image
+# Use node:20-alpine for LTS, or pin to a specific minor version with node:20.18.0-alpine
 FROM node:25-alpine
 
 # 2. Set the working directory inside the container


### PR DESCRIPTION
## Summary
- Add a brief comment in the Dockerfile noting how to switch to an LTS / pinned Node version.
- The current image uses `node:25-alpine` (a non-LTS version), which makes builds non-reproducible and may not match what Next.js 15 / React 19 are tested against.

## Change
Single-line comment above the `FROM` line in `Dockerfile`:

```dockerfile
# Use node:20-alpine for LTS, or pin to a specific minor version with node:20.18.0-alpine
```

## Why
- `node:25-alpine` floats to the latest Node 25.x release on every rebuild, which can break builds unexpectedly.
- Pinning to `node:20-alpine` (LTS) or a specific minor (e.g. `node:20.18.0-alpine`) makes builds reproducible and easier to audit.
- This is a docs-only change — no functional code is modified.